### PR TITLE
Merge UnitfulConventionalMoles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ os:
 julia:
   - 1.0
   - 1.3
+  - 1.4
+  - 1.5
   - nightly
 notifications:
   email: false

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,12 +3,63 @@
 [![Build Status](https://travis-ci.org/rafaqz/UnitfulMoles.jl.svg?branch=master)](https://travis-ci.org/rafaqz/UnitfulMoles.jl)
 [![codecov.io](http://codecov.io/github/cesaraustralia/Dispersal.jl/coverage.svg?branch=master)](http://codecov.io/github/rafaqz/UnitfulMoles.jl?branch=master)
 
-This package provides a standardised method for defining mol units for the Julia
-language, using Unitful.jl.
+This package provides a set of predefined conventional elemental mol units (like `molC` for moles of carbon) and a standardised method for defining custom mol units for the Julia language.
+It essentially extends the [Unitful.jl](https://github.com/PainterQubits/Unitful.jl) package.
 
-## Moles
+## Conventional mol units
 
-The main command is the `@mol` macro:
+Units are available as `u"molXXX"` for most of the elements of the periodic table (just replace `XXX` with the element's symbol).
+
+```julia
+julia> using UnitfulMoles
+
+julia> 3u"mmolFe" / 10u"molC"
+0.3 mmolFe molC⁻¹
+```
+
+You can also directly load the iron mmol and carbon mol units via
+
+```julia
+julia> using UnitfulMoles: mmolFe, molC
+
+julia> 3mmolFe / 10molC
+0.3 mmolFe molC⁻¹
+```
+
+## Molecular weight conversions
+
+Molar weights are provided for free, so you can convert from moles to grams effortlessly with Unitful's `uconvert` function (or the `|>` symbol):
+
+```julia
+julia> using UnitfulMoles
+
+julia> uconvert(u"g", 5u"mmolFe")
+0.279225 g
+
+julia> 200u"molC" |> u"kg"
+2.4021999999999997 kg
+```
+
+> **Note**:<br>
+    Atomic weights taken from *Atomic weights of the elements 2013 (IUPAC Technical  Report)* [doi:10.1515/pac-2015-0305](http://doi.org/10.1515/pac-2015-0305). Weights in g are provided with 5 digit precision, using "Conventional" weights where a range is provided instead of a specific value.
+
+## Compounds
+
+And you can create custom compounds with the `@compound` macro:
+
+```julia
+julia> using UnitfulMoles, Unitful
+
+julia> @compound H2O
+molH2O
+
+julia> 10molH2O |> u"g" # Molecular weight is calculated automatically!
+180.15 g
+```
+
+## Custom mol units
+
+For custom mol units, the main command is the `@mol` macro:
 
 ```julia
 julia> using UnitfulMoles, Unitful
@@ -24,53 +75,34 @@ julia> @mol B
 molB
 
 julia> 0.5molA/molB
-0.5 molA molB^-1
+0.5 molA molB⁻¹
 ```
+
+## Custom molar weights
 
 You can also assign a molar weight to the unit
 to allow conversion between mol and g:
 
 ```julia
-julia> @mol N 14.0067
-molN
+julia> @mol Foo 14.0067
+molFoo
 
-julia> uconvert(u"g", 5molN)
+julia> uconvert(u"g", 5molFoo)
 70.0335 g
 ```
 
-A set of predefined mol units is maintained separately in
-[UnitfulConventionalMoles.jl](https://github.com/rafaqz/UnitfulConventionalMoles.jl).
+## Compose and convert on the fly
 
-## Compounds
-
-The `@compound` macro lets you combine basic elements into compound molecules:
+You can use these macros in assignments:
 
 ```julia
-julia> @mol O 15.999
-molO
-
-julia> @compound NO3
-molNO3
-```
-
-And weight conversions work for free!
-
-```julia
-julia> uconvert(u"g", 10molNO3)
-620.037 g
-```
-
-You can also use these macros in assignments:
-
-```julia
-julia> @mol C 12.011
-molC
+julia> using UnitfulMoles, Unitful
 
 julia> x = (100@compound CO2) / 25u"L"
-4.0 L^-1 molCO2
+4.0 molCO2 L⁻¹
 
-julia> uconvert(u"g/L", x)
-176.036 g L^-1
+julia> x |> u"g/L"
+176.036 g L⁻¹
 ```
 
 ## C-mol and others
@@ -80,8 +112,7 @@ compound. The best example is the C-mole, which measure the amount of a compound
 relative to one mole of C:
 
 ```julia
-julia> @mol H 1.008
-molH
+julia> using UnitfulMoles
 
 julia> @xmol C C8H10N4O2
 C-molC8H10N4O2
@@ -93,5 +124,5 @@ julia> uconvert(CmolC8H10N4O2, 1molC8H10N4O2)
 8.0 C-molC8H10N4O2
 
 julia> uconvert(u"g", 1CmolC8H10N4O2)
-24.274099999999997 g
+24.27425 gg
 ```

--- a/src/ConventionalMoles.jl
+++ b/src/ConventionalMoles.jl
@@ -1,0 +1,176 @@
+# Atomic weights taken from:
+
+# Atomic weights of the elements 2013 (IUPAC Technical  Report)
+# http://doi.org/10.1515/pac-2015-0305
+
+# The "Conventional" weights are used where a range is provided, shown in comments.
+
+# hydrogen 1
+@mol H 1.008 # [1.0078, 1.0082]
+# helium 2
+@mol He 4.0026
+# lithium 3
+@mol Li 6.94 # [6.938, 6.997]
+# beryllium 4
+@mol Be 9.0122
+# boron 5
+@mol B 10.81 # [10.806, 10.821]
+# carbon 6
+@mol C 12.011 # [12.009, 12.012]
+# nitrogen 7
+@mol N 14.007 # [14.006, 14.008]
+# oxygen 8
+@mol O 15.999 # [15.999, 16.000]
+# fluorine 9
+@mol F 18.998
+# neon 10
+@mol Ne 20.180
+# sodium 11
+@mol Na 22.990
+# magnesium 12
+@mol Mg 24.305 # [24.304, 24.307]
+# aluminium (aluminum) 13
+@mol Al 26.982
+# silicon 14
+@mol Si 28.085 # [28.084, 28.086]
+# phosphorus 15
+@mol P 30.974
+# sulfur 16
+@mol S 32.06 # [32.059, 32.076]
+# chlorine 17
+@mol Cl 35.45 # [35.446, 35.457]
+# argon 18
+@mol Ar 39.948
+# potassium 19
+@mol K 39.098
+# calcium 20
+@mol Ca 40.078 # (4)
+# scandium 21
+@mol Sc 44.956
+# titanium 22
+@mol Ti 47.867
+# vanadium 23
+@mol V 50.942
+# chromium 24
+@mol Cr 51.996
+# manganese 25
+@mol Mn 54.938
+# iron 26
+@mol Fe 55.845 # (2)
+# cobalt 27
+@mol Co 58.933
+# nickel 28
+@mol Ni 58.693
+# copper 29
+@mol Cu 63.546 # (3)
+# zinc 30
+@mol Zn 65.38 # (2)
+# gallium 31
+@mol Ga 69.723
+# germanium 32
+@mol Ge 72.630 # (8)
+# arsenic 33
+@mol As 74.922
+# selenium 34
+@mol Se 78.971 # (8)
+# bromine 35
+@mol Br 79.904 # [79.901, 79.907]
+# krypton 36
+@mol Kr 83.798 # (2)
+# rubidium 37
+@mol Rb 85.468
+# strontium 38
+@mol Sr 87.62
+# yttrium 39
+@mol Y 88.906
+# zirconium 40
+@mol Zr 91.224 # (2)
+# niobium 41
+@mol Nb 92.906
+# molybdenum 42
+@mol Mo 95.95
+# technetium* 43
+# @mol Tc –
+# ruthenium 44
+@mol Ru 101.07 # (2)
+# rhodium 45
+@mol Rh 102.91
+# palladium 46
+@mol Pd 106.42
+# silver 47
+@mol Ag 107.87
+# cadmium 48
+@mol Cd 112.41
+# indium 49
+@mol In 114.82
+# tin 50
+@mol Sn 118.71
+# antimony 51
+@mol Sb 121.76
+# tellurium 52
+@mol Te 127.60 # (3)
+# iodine 53
+@mol I 126.90
+# xenon 54
+@mol Xe 131.29
+# caesium (cesium) 55
+@mol Cs 132.91
+# barium 56
+@mol Ba 137.33
+# lanthanum 57
+@mol La 138.91
+# cerium 58
+@mol Ce 140.12
+# praseodymium 59
+@mol Pr 140.91
+# neodymium 60
+@mol Nd 144.24
+# promethium* 61
+# @mol Pm –
+# samarium 62
+@mol Sm 150.36 # (2)
+# europium 63
+@mol Eu 151.96
+# gadolinium 64
+@mol Gd 157.25 # (3)
+# terbium 65
+@mol Tb 158.93
+# dysprosium 66
+@mol Dy 162.50
+# holmium 67
+@mol Ho 164.93
+# erbium 68
+@mol Er 167.26
+# thulium 69
+@mol Tm 168.93
+# ytterbium 70
+@mol Yb 173.05
+# lutetium 71
+@mol Lu 174.97
+# hafnium 72
+@mol Hf 178.49 # (2)
+# tantalum 73
+@mol Ta 180.95
+# tungsten 74
+@mol W 183.84
+# rhenium 75
+@mol Re 186.21
+# osmium 76
+@mol Os 190.23 # (3)
+# iridium 77
+@mol Ir 192.22
+# platinum 78
+@mol Pt 195.08
+# gold 79
+@mol Au 196.97
+# mercury 80
+@mol Hg 200.59
+# thallium 81
+@mol Tl 204.38 # [204.38, 204.39]
+# lead 82
+@mol Pb 207.2
+# bismuth* 83
+@mol Bi 208.98
+
+
+

--- a/src/UnitfulMoles.jl
+++ b/src/UnitfulMoles.jl
@@ -11,7 +11,7 @@ The @mol macro lets you declare specific molar units.
 
 Usage example:
 ```
-julia> @mol N 
+julia> @mol N
 julia> 2μmolN
 2 μmolN
 ```
@@ -154,6 +154,15 @@ function getweight(arg::String)
         w = eval(Meta.parse("""uconvert(u"g", 1u"mol$arg")"""))
     end
     return w
+end
+
+include("ConventionalMoles.jl")
+
+# Allow precompile, and register mol units with u_str macro.
+const localunits = Unitful.basefactors
+function __init__()
+    merge!(Unitful.basefactors, localunits)
+    Unitful.register(UnitfulMoles)
 end
 
 end # module


### PR DESCRIPTION
I keep coming back to UnitfulMoles and UnitfulConventionalMoles and I figured I would use them more if they were merged into a single one. So this PR essentially includes UnitfulConventionalMoles into UnitfulMoles. I also made a fair amount of ReadMe edits to include the features from conventional moles stuff.

I also think you should register the package so that more people see it (and use it)! With the ever-growing popularity of Julia and the Unitful package, UnitfulMoles is a very nice, shiny thing to showcase to newcomers and researchers that would use Julia first as an advanced calculator. To them, doing all the unit converting for free feels like sweet, sweet magic. I work mainly in oceanography, and we always have to deal with stoichiometry and mol to weight conversions. This simple, self-contained MWE (in this PR's ReadMe)

```julia
julia> using UnitfulMoles: mmolFe, molC

julia> 3mmolFe / 10molC
0.3 mmolFe molC⁻¹
```

might be enough to convert some of these scientists to Julia. Not that I really have anything to gain from Julia's success, but I just wanted to point out how cool it looks, and I think it deserves more exposition. And that your hard work should be recognized, too! 👍 

Do with this PR as you will!

Cheers!


