### PR TITLE
Prettify componds with unicode subscripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - osx
   - windows
 julia:
-  - 1.0
   - 1.3
   - 1.4
   - 1.5

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -51,10 +51,16 @@ And you can create custom compounds with the `@compound` macro:
 julia> using UnitfulMoles, Unitful
 
 julia> @compound H2O
-molH2O
+molH₂O
 
-julia> 10molH2O |> u"g" # Molecular weight is calculated automatically!
+julia> 10molH₂O |> u"g" # Molecular weight is calculated automatically!
 180.15 g
+
+julia> @compound CH₄ # subscripts work as well (and look nicer, too!)
+molCH₄
+
+julia> 1molCH₄ |> u"g"
+16.043 g
 ```
 
 ## Custom mol units
@@ -99,7 +105,7 @@ You can use these macros in assignments:
 julia> using UnitfulMoles, Unitful
 
 julia> x = (100@compound CO2) / 25u"L"
-4.0 molCO2 L⁻¹
+4.0 molCO₂ L⁻¹
 
 julia> x |> u"g/L"
 176.036 g L⁻¹
@@ -114,15 +120,15 @@ relative to one mole of C:
 ```julia
 julia> using UnitfulMoles
 
-julia> @xmol C C8H10N4O2
-C-molC8H10N4O2
+julia> @xmol C C₈H₁₀N₄O₂
+C-molC₈H₁₀N₄O₂
 
-julia> uconvert(molC8H10N4O2, 1CmolC8H10N4O2)
-0.125 molC8H10N4O2
+julia> uconvert(molC₈H₁₀N₄O₂, 1CmolC₈H₁₀N₄O₂)
+0.125 molC₈H₁₀N₄O₂
 
-julia> uconvert(CmolC8H10N4O2, 1molC8H10N4O2)
-8.0 C-molC8H10N4O2
+julia> uconvert(CmolC₈H₁₀N₄O₂, 1molC₈H₁₀N₄O₂)
+8.0 C-molC₈H₁₀N₄O₂
 
-julia> uconvert(u"g", 1CmolC8H10N4O2)
+julia> uconvert(u"g", 1CmolC₈H₁₀N₄O₂)
 24.27425 gg
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,9 +28,10 @@ end
 
 @testset "Compound weight is the sum of its components" begin
     @compound FooBar2
-    @test uconvert(u"g", 1molFooBar2) == 255.3u"g"
-    @compound Foo4Bar
-    @test uconvert(u"g", 1molFoo4Bar) == 321.9u"g"
+    @test uconvert(u"g", 1molFooBar₂) == 255.3u"g"
+    @compound Foo₄Bar
+    @test uconvert(u"g", 1molFoo₄Bar) == 321.9u"g"
+    @compound Foo90Bar
 end
 
 @testset "Sum base" begin
@@ -41,12 +42,16 @@ end
 
 @testset "Parse compound" begin
     @test UnitfulMoles.parse_compound("CO2") == ["C" => 1, "O" => 2]
+    @test UnitfulMoles.parse_compound("CO₂") == ["C" => 1, "O" => 2]
     @test UnitfulMoles.parse_compound("NaCl") == ["Na" => 1, "Cl" => 1]
     @test UnitfulMoles.parse_compound("C8H10N4O2") == ["C" => 8, "H" => 10, "N" => 4, "O" => 2]
+    @test UnitfulMoles.parse_compound("C₈H₁₀N₄O₂") == ["C" => 8, "H" => 10, "N" => 4, "O" => 2]
 end
 
 @testset "xmols are the correct fraction of their compound" begin
-    @xmol Bar FooBar2
-    1molFooBar2 == 2BarmolFooBar2
+    @xmol Bar FooBar₂
+    1molFooBar₂ == 2BarmolFooBar₂
+    @xmol Bar Foo4Bar
+    4molFoo₄Bar == 1BarmolFoo₄Bar
 end
 


### PR DESCRIPTION
This PR modifies the compound functions a little bit so that you can create with or without subscripts, and the created/displayed compounds are always printed with subscripts. MWE::

```julia
julia> using UnitfulMoles, Unitful

julia> @compound H2O
molH₂O

julia> 1molH₂O |> u"g"
18.015 g

julia> @compound CH₄
molCH₄

julia> 1molCH₄ |> u"g"
16.043 g
```

which looks prettier IMHO. 

I will let you decide whether to merge this and then I think I will just release it with a JuliaRegistrator comment? 

(BTW could you check if JuliaRegistrator is enabled?)