### PR TITLE
Make this package slightly saner by removing all `eval`

### DIFF
--- a/src/UnitfulMoles.jl
+++ b/src/UnitfulMoles.jl
@@ -77,8 +77,8 @@ macro compound(name::Symbol)
     
     sum_expr = Expr(:block, :(weight = 0.0u"g")) 
     for (el, n) in elements
-        x = Symbol("mol$el")
-        w = :(Unitful.uconvert(u"g", 1 * $x))
+        x = "mol$el"
+        w = :(Unitful.uconvert(u"g", 1 * (@u_str $x)))
         push!(sum_expr.args, :(weight += $n * $w))
     end
     name = Symbol(subscriptify(string(name)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,10 @@
 using Unitful, UnitfulMoles, Test
 
+
 @mol Baz
 @mol Foo 55.5
-@mol Bar 99.9
+x = 99.9
+@mol Bar x
 
 @testset "Printing" begin
     @test string(3molBaz) == "3 molBaz"


### PR DESCRIPTION
This PR removes `eval` and uses regular AST transformations and functions like any sane person would want to. Also escapes outputs properly so code is hopefully never evaluated into UnitfulMoles.jl from another package.

Closes #14

@AlexisRenchon please try this out wit `] add UnitfulMoles#sanity`. I've been using it with your package and it seems to work for me now.